### PR TITLE
Add tests to support zksync

### DIFF
--- a/src/HatsModule.sol
+++ b/src/HatsModule.sol
@@ -6,7 +6,7 @@ import { IHats } from "hats-protocol/Interfaces/IHats.sol";
 import { IHatsModule } from "./interfaces/IHatsModule.sol";
 import { Initializable } from "@openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
 
-contract HatsModule is IHatsModule {
+contract HatsModule is IHatsModule, Initializable {
   IHats immutable zkHats;
   uint256 immutable zkHatId;
 
@@ -38,7 +38,7 @@ contract HatsModule is IHatsModule {
   //////////////////////////////////////////////////////////////*/
 
   /// @inheritdoc IHatsModule
-  function setUp(bytes calldata _initData) public {
+  function setUp(bytes calldata _initData) public initializer {
     _setUp(_initData);
   }
 
@@ -53,7 +53,7 @@ contract HatsModule is IHatsModule {
   /// @dev This is only used to deploy the implementation contract, and should not be used to deploy clones
   constructor(string memory _version, address _hat, uint256 _hatId) {
     version_ = _version;
-	zkHats = IHats(_hat);
-	zkHatId = _hatId;
+    zkHats = IHats(_hat);
+    zkHatId = _hatId;
   }
 }

--- a/test/HatsModule.t.sol
+++ b/test/HatsModule.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import { Test, console2 } from "forge-std/Test.sol";
+import { HatsModule, IHats } from "../src/HatsModule.sol";
+
+contract HatsModuleTest is Test {
+  event HatsModuleHarness_SetUp(bytes initData);
+
+  string public MODULE_VERSION = "test module";
+  address hatAddress = makeAddr("this is a hat address");
+  uint256 hatId = 1;
+  HatsModule public hatsModule;
+  bytes largeBytes =
+    abi.encodePacked("This is a fairly large bytes object, but is it really? Yes it is, it's quite large");
+  uint256 public largeBytesLength = largeBytes.length;
+
+  function _deployModule(string memory _moduleVersion, address _hatAddress, uint256 _hatId) public virtual {
+    // super.setUp();
+    // deploy a new HatsModule to be tested by the test contracts below
+    hatsModule = new HatsModule(_moduleVersion, _hatAddress, _hatId);
+  }
+
+  function testFuzz_version(string memory _version) public {
+    _deployModule(_version, hatAddress, hatId);
+    assertEq(hatsModule.version_(), _version, "incorrect module version");
+  }
+
+  function testFuzz_hatAddress(address _hatAddress) public {
+    _deployModule(MODULE_VERSION, _hatAddress, hatId);
+    assertEq(address(hatsModule.HATS()), _hatAddress, "incorrect hat address");
+  }
+
+  function testFuzz_hatId(uint256 _hatId) public {
+    _deployModule(MODULE_VERSION, hatAddress, _hatId);
+    assertEq(hatsModule.hatId(), _hatId, "incorrect hat id");
+  }
+}

--- a/test/HatsModule.t.sol
+++ b/test/HatsModule.t.sol
@@ -16,7 +16,6 @@ contract HatsModuleTest is Test {
   uint256 public largeBytesLength = largeBytes.length;
 
   function _deployModule(string memory _moduleVersion, address _hatAddress, uint256 _hatId) public virtual {
-    // super.setUp();
     // deploy a new HatsModule to be tested by the test contracts below
     hatsModule = new HatsModule(_moduleVersion, _hatAddress, _hatId);
   }

--- a/test/HatsModule.t.sol
+++ b/test/HatsModule.t.sol
@@ -34,4 +34,10 @@ contract HatsModuleTest is Test {
     _deployModule(MODULE_VERSION, hatAddress, _hatId);
     assertEq(hatsModule.hatId(), _hatId, "incorrect hat id");
   }
+
+  function test_setUpCannotBeCalledTwice() public {
+    // expect revert if setUp is called again
+    vm.expectRevert();
+    hatsModule.setUp(abi.encode("another setUp attempt"));
+  }
 }


### PR DESCRIPTION
This PR also adds the 'initializer' modifier back on the hats module 'setup' function.